### PR TITLE
replace os.system() with subprocess.Popen() (tmp output files are not needed now)

### DIFF
--- a/plugins/dssp_stride.py
+++ b/plugins/dssp_stride.py
@@ -725,8 +725,8 @@ Hongbo Zhu. DSSP and Stride plugin for PyMOL, 2011, BIOTEC, TU Dresden.
         # clean up pdb_fn and dssp_tmpout_fn created by tempfile.mkstemp()
         if os.path.isfile(pdb_fn):
             os.remove(pdb_fn)
-        if os.path.isfile(stride_tmpout_fn):
-            os.remove(stride_tmpout_fn)        
+##         if os.path.isfile(stride_tmpout_fn):
+##             os.remove(stride_tmpout_fn)        
         
         return True
     


### PR DESCRIPTION
Hi, 

As the author or dssp_stride plugin, I have updated the dssp_stride.py file by replacing os.system() with subprocess.Popen() such that 
1. os.system() is removed in the script;
2. temp output files from DSSP/Stride are not needed.

thanks!
Hongbo
