### PR TITLE
check python version before import subprocess

### DIFF
--- a/plugins/dssp_stride.py
+++ b/plugins/dssp_stride.py
@@ -166,10 +166,6 @@ class DSSPPlugin:
         else:
             if VERBOSE: print 'STRIDE_BIN not found in environmental variables.'
             self.stride_bin.set('')
-        # this is line crashes the plugin if the array returned by 
-        # cmd.get_names() is empty. 
-        # And this feature can easily confuse users by setting the 1st obj
-        # self.pymol_sel.set(cmd.get_names('objects')[0])
         
         # DSSP visualization color
         # - H        Alpha helix (4-12) 


### PR DESCRIPTION
some users who are using old free pymol compilation complained that subprocess is not available. So I revised the code so that it checks python version before import subprocess. os.system is used if python version is lower than 2.4, when subprocess was introduced.
