### PR TITLE
Add Color Blind Friendly colors with colorblindfriendly.py

### DIFF
--- a/colorblindfriendly.py
+++ b/colorblindfriendly.py
@@ -104,6 +104,3 @@ cmd.set_color("cb_rose", reddish_purple)
 cmd.set_color("cb_violet", reddish_purple)
 cmd.set_color("cb_magenta", reddish_purple)
 
-
-# TODO:
-# * override certain features, like util.cnc(), to use these colors

--- a/elbow_angle.py
+++ b/elbow_angle.py
@@ -153,11 +153,11 @@ REQUIRES: com.py, transformations.py, numpy (see above)
     if (numpy.dot(direction_v,direction_c)>0):
         direction_c = direction_c * -1   # ensure angle is > 90 (need to standardize this)
         
-        # TODO: make both directions point away from the elbow axis.  how?
+        # TODO: make both directions point away from the elbow axis.
 
     elbow = int(numpy.degrees(numpy.arccos(numpy.dot(direction_v,direction_c))))
-#    while (elbow < 90):
-#        elbow = 180 - elbow   # limit to physically reasonable range
+    # while (elbow < 90):
+    #     elbow = 180 - elbow   # limit to physically reasonable range
             
        
     # compare the direction_v and direction_c axes to the vector defined by
@@ -225,6 +225,3 @@ REQUIRES: com.py, transformations.py, numpy (see above)
     return 0
         
 cmd.extend("elbow_angle",elbow_angle)
-
-
-


### PR DESCRIPTION
This script creates a series of colorblind-friendly colors (from [here](http://jfly.iam.u-tokyo.ac.jp/html/color_blind/)) that can be used to color PyMOL objects and selections.  These are unambiguous to both colorblind and non-colorblind individuals.

(Bonus: Also included are a couple of changes I made to clean up comments in elbow_angle.py but never pushed.)
