### PR TITLE
Work around for #63

### DIFF
--- a/plugins/pyanm.py
+++ b/plugins/pyanm.py
@@ -53,8 +53,13 @@ except ImportError:
     raise ImportError('Failed to import numpy, which is required for building ANM')
     
 try:
-    import scipy.sparse.linalg
-    haveSP = True
+    # In MacPyMOL, even importing linalg causes a crash
+    import platform
+    if platform.system() == 'Darwin':
+        haveSP = False
+    else:
+        import scipy.sparse.linalg
+        haveSP = True
 except ImportError:
     haveSP = False
 


### PR DESCRIPTION
Ignores scipy.sparse.linalg on Macs. This is overkill if pymol was
compiled correctly with a working linalg module, but it prevents a
serious crash for users of pre-built MacPyMOL.
