### PR TITLE
Update format_bonds.py

### DIFF
--- a/format_bonds.py
+++ b/format_bonds.py
@@ -251,13 +251,9 @@ ARGUMENTS
         ['CZ', 'NH1'],
         ['CZ', 'NH2']
     ]
-<<<<<<< HEAD
+
     ARG_bonds_double=[
     ['CZ','NH1']
-=======
-    ARG_bonds_double = [
-        ['C', 'NH1']
->>>>>>> autopep8
     ]
 
     ##### FORMATING #####


### PR DESCRIPTION
A previous effort to correct syntax in the pymol repository introduced some "junk" code into this script causing it to crash. I got an email about it and deleted the affected lines.
Note the deletion of the "autopep8" stuff formerly in line 254ff.