### PR TITLE
flatten_obj script

### DIFF
--- a/flatten_obj.py
+++ b/flatten_obj.py
@@ -15,6 +15,7 @@ re-lettering should occur.
 Author: Spencer Bliven <spencer.bliven@gmail.com>
 Date: October 30, 2015
 Version: 1.0
+License: Public Domain
 """
 from pymol import cmd, stored
 import re

--- a/flatten_obj.py
+++ b/flatten_obj.py
@@ -1,3 +1,10 @@
+"""
+flatten_obj.py - Flatten multi-state pymol objects into a single state.
+
+Author: Spencer Bliven <spencer.bliven@gmail.com>
+Date: October 30, 2015
+Version: 1.0
+"""
 from pymol import cmd, stored
 import re
 try:
@@ -324,4 +331,5 @@ SEE ALSO
 cmd.extend('flatten_obj', flatten_obj)
 
 # tab-completion of arguments
-#cmd.auto_arg[3]['flatten_obj'] = [ cmd.object_sc, 'object', '']
+cmd.auto_arg[0]['flatten_obj'] = [ cmd.object_sc, 'name or selection', '']
+cmd.auto_arg[1]['flatten_obj'] = [ cmd.object_sc, 'selection', '']

--- a/flatten_obj.py
+++ b/flatten_obj.py
@@ -1,6 +1,17 @@
 """
 flatten_obj.py - Flatten multi-state pymol objects into a single state.
 
+This is particularly useful for dealing with biological assemblies, which are
+loaded as multi-state objects when fetched using `fetch PDBID, type=pdb1`. It
+can also be used as a quick way to combine multiple objects without causing
+collisions between chain identifiers.
+
+The command re-letters chains to avoid collisions. Older versions of PyMOL
+restrict the chain id to a single character, so the script will fail for
+assemblies with >62 chains. With more recent versions, this problem is solved
+with multi-character chain IDs. Several options are available for how
+re-lettering should occur.
+
 Author: Spencer Bliven <spencer.bliven@gmail.com>
 Date: October 30, 2015
 Version: 1.0


### PR DESCRIPTION
flatten_obj.py - Flatten multi-state pymol objects into a single state.

This is particularly useful for dealing with biological assemblies, which are
loaded as multi-state objects when fetched using `fetch PDBID, type=pdb1`. It
can also be used as a quick way to combine multiple objects without causing
collisions between chain identifiers.

The command re-letters chains to avoid collisions. Older versions of PyMOL
restrict the chain id to a single character, so the script will fail for
assemblies with >62 chains. With more recent versions, this problem is solved
with multi-character chain IDs. Several options are available for how
re-lettering should occur.