### PR TITLE
Fixed issue of floats that were causing errors

### DIFF
--- a/spectrumany.py
+++ b/spectrumany.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 '''
 http://pymolwiki.org/index.php/spectrumany
 

--- a/spectrumany.py
+++ b/spectrumany.py
@@ -86,7 +86,7 @@ SEE ALSO
         val_range = maximum - minimum
         cmd.color(colors[0], selection)
 
-    steps = int(60 / parts)
+    steps = 60 // parts
     steps_total = steps * parts
 
     val_start = minimum

--- a/spectrumany.py
+++ b/spectrumany.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 '''
 http://pymolwiki.org/index.php/spectrumany
 
@@ -86,7 +89,7 @@ SEE ALSO
         val_range = maximum - minimum
         cmd.color(colors[0], selection)
 
-    steps = 60 / parts
+    steps = int(60 / parts)
     steps_total = steps * parts
 
     val_start = minimum
@@ -94,7 +97,7 @@ SEE ALSO
         for i in range(steps):
             ii = float(i) / steps
             col_list = [colvec[p + 1][j] * ii + colvec[p][j] * (1.0 - ii) for j in range(3)]
-            col_name = '0x%02x%02x%02x' % (col_list[0] * 255, col_list[1] * 255, col_list[2] * 255)
+            col_name = '0x%02x%02x%02x' % (int(col_list[0] * 255), int(col_list[1] * 255), int(col_list[2] * 255))
             val_end = val_range * (i + 1 + p * steps) / steps_total + minimum
             if expression in discrete_expr:
                 cmd.color(col_name, '(%s) and %s %d-%d' % (selection, expression, val_start, val_end))


### PR DESCRIPTION
When I ran spectrumany in Pymol I got the following errors as a result of the changes of integer to floating division with python 3:

```
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/pymol/2.5.0/libexec/lib/python3.9/site-packages/pmg_tk/startup/spectrumany.py", line 94, in spectrumany
    for i in range(steps):
TypeError: 'float' object cannot be interpreted as an integer
```

The changes fix the issues
