### PR TITLE
Update tmalign.py for python 3.11

### DIFF
--- a/tmalign.py
+++ b/tmalign.py
@@ -170,7 +170,7 @@ SEE ALSO
             print('')
 
     assert len(matrix) == 3 * 4
-    matrix.extend([0, 0, 0, 1])
+    matrix.extend([0.0, 0.0, 0.0, 1.0])
 
     if int(transform):
         cmd.transform_selection('byobject (%s)' % (mobile), matrix, homogenous=1)


### PR DESCRIPTION
Currently with OSX python3.11 (m1) I get a nasty crash (segment below) because python3.11 calls pyfloat_fromdouble on an integer. changing them to floats fixes the crash.

```
System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000010
Exception Codes:       0x0000000000000001, 0x0000000000000010

Termination Reason:    Namespace SIGNAL, Code 11 Segmentation fault: 11
Terminating Process:   exc handler [30753]

VM Region Info: 0x10 is not in any region.  Bytes before following region: 105553518919664
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      MALLOC_NANO (reserved)   600018000000-600020000000 [128.0M] rw-/rwx SM=NUL  ...(unallocated)

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   python3.11                    	       0x102fcc364 PyFloat_FromDouble + 32
1   python3.11                    	       0x102fca5c8 PyFloat_AsDouble + 256
2   python3.11                    	       0x102fca5c8 PyFloat_AsDouble + 256
3   _cmd.cpython-311-darwin.so    	       0x104260d4c PConvPyListToFloatArrayInPlace(_object*, float*, unsigned long) + 140
4   _cmd.cpython-311-darwin.so    	       0x1044226a4 CmdTransformSelection(_object*, _object*) + 468
5   python3.11                    	       0x102ffe2e4 cfunction_call + 284
6   python3.11                    	       0x102fa78c4 _PyObject_MakeTpCall + 332
7   python3.11                    	       0x1030a433c _PyEval_EvalFrameDefault + 46132
8   python3.11                    	       0x1030a88c0 _PyEval_Vector + 184 
```