### PR TITLE
Add output message for findseq + don't create empty selection when seq was not found

### DIFF
--- a/findseq.py
+++ b/findseq.py
@@ -77,8 +77,6 @@ def findseq(needle, haystack, selName=None, het=0, firstOnly=0):
     if selName == None:
         rSelName = "foundSeq" + str(random.randint(0, 32000))
         selName = rSelName
-    elif selName == "sele":
-        rSelName = "sele"
     else:
         rSelName = selName
 
@@ -376,9 +374,13 @@ def findseq(needle, haystack, selName=None, het=0, firstOnly=0):
         if int(firstOnly):
             break
     cmd.delete("__h")
-    if not cmd.count_atoms(rSelName):
+    cnt = cmd.count_atoms(rSelName)
+    if not cnt:
         print("Sequence was not found")
         cmd.delete(rSelName)
+        return None
+
+    print(f'findseq: selection "{rSelName}" defined with {cnt} atoms.')
     return rSelName
 
 cmd.extend("findseq", findseq)

--- a/findseq.py
+++ b/findseq.py
@@ -376,6 +376,9 @@ def findseq(needle, haystack, selName=None, het=0, firstOnly=0):
         if int(firstOnly):
             break
     cmd.delete("__h")
+    if not cmd.count_atoms(rSelName):
+        print("Sequence was not found")
+        cmd.delete(rSelName)
     return rSelName
 
 cmd.extend("findseq", findseq)


### PR DESCRIPTION
The current behavior doesn't output any message whether a sequence was found or not, so the only way to check is by noticing that the selection is empty.

I think a better method would be to not create an empty selection, as well as printing messages for both cases.